### PR TITLE
Fix case-study runner: CWD-independent paths and clear task_repo error

### DIFF
--- a/case-study/runner/README.md
+++ b/case-study/runner/README.md
@@ -23,7 +23,8 @@ this runner deliberately doesn't fake those.
 
 ```bash
 cp case-study/runner/arms.example.json case-study/runner/arms.json
-# edit arms.json: set task_repo to your task_ist_preprocessing clone, set models
+# REQUIRED: edit arms.json -> set "task_repo" to your task_ist_preprocessing
+# clone (and set the models). A real run errors clearly if it's left unset.
 
 # validate the plan without running anything:
 python case-study/runner/run.py --config case-study/runner/arms.json --dry-run
@@ -34,6 +35,11 @@ python case-study/runner/run.py --config case-study/runner/arms.json
 ```
 
 Output: `case-study/runs/results.json` and `results.md`.
+
+> **Run it from anywhere.** Paths in the config (`copilot_repo`, `workdir`,
+> `prompt_file`) resolve against the repo root, not your current directory — so
+> `python runner/run.py ...` from inside `case-study/` works too. Only the
+> `--config` path itself is taken relative to your shell's working directory.
 
 ## Smoke-test offline first (no tokens, no setup)
 

--- a/case-study/runner/arms.example.json
+++ b/case-study/runner/arms.example.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "Copy to arms.json and edit. REQUIRED: set 'task_repo' to a local clone of openproblems-bio/task_ist_preprocessing (or use --mock-harness to smoke-test offline). Relative paths resolve against the repo root, so the runner works from any directory.",
   "copilot_repo": ".",
   "task_repo": "/path/to/task_ist_preprocessing",
   "component_name": "log_normalization",

--- a/case-study/runner/run.py
+++ b/case-study/runner/run.py
@@ -31,6 +31,7 @@ from pathlib import Path
 
 HERE = Path(__file__).resolve().parent
 CASE_STUDY = HERE.parent
+REPO_ROOT = CASE_STUDY.parent
 GRADE_PY = CASE_STUDY / "grade.py"
 STRIP_SH = CASE_STUDY / "scripts" / "strip_skill.sh"
 COPILOT_ASSETS = ("AGENTS.md", "skills", "context")
@@ -44,13 +45,25 @@ _FIXTURE = {
 }
 
 
+def _resolve(base: Path, value: str) -> Path:
+    """Resolve ``value`` as an absolute path, anchoring relatives at ``base``."""
+    p = Path(value).expanduser()
+    return p if p.is_absolute() else base / p
+
+
 def _load_config(path: Path) -> dict:
     cfg = json.loads(path.read_text(encoding="utf-8"))
-    cfg.setdefault("workdir", "case-study/runs")
     cfg.setdefault("component_name", "log_normalization")
     cfg.setdefault("timeout_seconds", 1800)
-    cfg.setdefault("prompt_file", "case-study/task/prompt.txt")
     cfg.setdefault("run_viash", False)
+    # Resolve paths against the repo root (derived from this script's location),
+    # NOT the current working directory, so the runner works from any directory.
+    copilot_repo = _resolve(REPO_ROOT, cfg.get("copilot_repo", ".")).resolve()
+    cfg["copilot_repo"] = str(copilot_repo)
+    cfg["workdir"] = str(_resolve(REPO_ROOT, cfg.get("workdir", "case-study/runs")))
+    cfg["prompt_file"] = str(
+        _resolve(copilot_repo, cfg.get("prompt_file", "case-study/task/prompt.txt"))
+    )
     return cfg
 
 
@@ -185,7 +198,7 @@ def grade_component(
 def run_arm(
     cfg: dict, arm: dict, copilot_repo: Path, dry_run: bool, mock: str | None = None
 ) -> dict:
-    prompt = (copilot_repo / cfg["prompt_file"]).read_text(encoding="utf-8").strip()
+    prompt = Path(cfg["prompt_file"]).read_text(encoding="utf-8").strip()
     result = {
         "arm": arm["name"],
         "harness": arm["harness"],
@@ -278,19 +291,40 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     cfg = _load_config(args.config)
-    copilot_repo = Path(cfg.get("copilot_repo", ".")).resolve()
+    copilot_repo = Path(cfg["copilot_repo"])
+
+    task_repo_val = str(cfg.get("task_repo", "")).strip()
+    task_repo = Path(task_repo_val).expanduser() if task_repo_val else None
 
     # In mock mode, synthesize a stand-in task repo if the configured one is absent
     # so the full prepare->run->grade pipeline runs with no external dependencies.
     if args.mock_harness and not args.dry_run:
-        task_repo = Path(cfg["task_repo"]).expanduser()
-        if not task_repo.exists():
-            synth = Path(cfg["workdir"]).resolve() / "_mock_task_repo"
+        if task_repo is None or not task_repo.exists():
+            synth = Path(cfg["workdir"]) / "_mock_task_repo"
             if synth.exists():
                 shutil.rmtree(synth)
             _synthesize_task_repo(synth)
             cfg["task_repo"] = str(synth)
             print(f"(mock) synthesized stand-in task repo at {synth}")
+    # Real run: fail early and clearly if task_repo is the unedited placeholder.
+    elif not args.dry_run:
+        if (
+            not task_repo_val
+            or task_repo_val.startswith("/path/to/")
+            or task_repo is None
+            or not task_repo.exists()
+        ):
+            print(
+                "❌ 'task_repo' is not set to a real checkout "
+                f"(current value: {task_repo_val or '(missing)'}).\n"
+                "   Edit your arms config and point it at a local clone of\n"
+                "   openproblems-bio/task_ist_preprocessing, for example:\n"
+                '       "task_repo": "/home/you/task_ist_preprocessing"\n'
+                "   Or smoke-test the pipeline offline first with no clone:\n"
+                "       --mock-harness skill-aware",
+                file=sys.stderr,
+            )
+            return 2
 
     arms = cfg["arms"]
     if args.only:

--- a/tests/test_case_study_runner.py
+++ b/tests/test_case_study_runner.py
@@ -107,3 +107,30 @@ def test_mock_end_to_end(tmp_path):
     by_arm = {r["arm"]: r["graded"]["score"] for r in results}
     assert by_arm["skill"] == 11
     assert by_arm["noskill"] == 0
+
+
+def test_config_paths_are_cwd_independent(tmp_path, monkeypatch):
+    """Paths resolve against the repo root, not the current working directory."""
+    monkeypatch.chdir(tmp_path)  # run from an unrelated directory
+    cfg = run_mod._load_config(EXAMPLE_CONFIG)
+    prompt = Path(cfg["prompt_file"])
+    assert prompt.is_absolute() and prompt.is_file()
+    assert prompt == REPO_ROOT / "case-study" / "task" / "prompt.txt"
+    assert Path(cfg["copilot_repo"]) == REPO_ROOT
+    assert Path(cfg["workdir"]).is_absolute()
+
+
+def test_real_run_rejects_placeholder_task_repo(tmp_path, capsys):
+    """A real run with the unedited placeholder fails clearly (exit 2)."""
+    config = {
+        "copilot_repo": str(REPO_ROOT),
+        "task_repo": "/path/to/task_ist_preprocessing",
+        "workdir": str(tmp_path / "runs"),
+        "arms": [{"name": "x", "harness": "gemini", "model": "m", "skill": False}],
+        "harnesses": {"gemini": {"command": ["gemini", "-p", "{prompt}"]}},
+    }
+    cfg_path = tmp_path / "arms.json"
+    cfg_path.write_text(json.dumps(config), encoding="utf-8")
+    rc = run_mod.main(["--config", str(cfg_path)])
+    assert rc == 2
+    assert "task_repo" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Follow-up to #4 (merged). Fixes two usability bugs in the case-study runner that
surfaced on a real run, rebased onto current `main` as a single commit.

## What's fixed

1. **Runs from any directory.** Config paths (`prompt_file`, `workdir`,
   `copilot_repo`) resolved against the current working directory, so the runner
   only worked from the project root and doubled paths
   (`case-study/case-study/task/prompt.txt`) when run from `case-study/`. They
   now resolve against the repo root derived from the script's location. Only the
   `--config` path stays relative to your shell.

2. **Clear error for an unset `task_repo`.** The unedited placeholder
   (`/path/to/task_ist_preprocessing`) crashed with a raw `FileNotFoundError`
   deep in `shutil.copytree`. A real run now preflights `task_repo` and exits `2`
   with an actionable message pointing at the config and the offline
   `--mock-harness` option.

Also: `arms.example.json` gains a `_comment` making the `task_repo` requirement
explicit; `runner/README` notes the run-from-anywhere behavior; 2 regression
tests added (CWD-independent path resolution; placeholder → exit 2).

## Verification

- **96 tests pass** (1 skipped); generated agent files in sync
- Verified all three previously-failing invocations: dry-run from `case-study/`,
  the placeholder error (exit 2), and `--mock-harness` from `case-study/`
- Rebased onto current `main` (fast-forwardable, no conflicts)

https://claude.ai/code/session_01KedkjeNphkH8BvRYuGNDzq

---
_Generated by [Claude Code](https://claude.ai/code/session_01KedkjeNphkH8BvRYuGNDzq)_